### PR TITLE
Possibility to specify the psalm config paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,14 @@
 					],
 					"default": false,
 					"description": "If this is set to true, this VSCode extension will use TCP instead of the default STDIO to communicate with the Psalm language server. (Modifying requires restart)"
+				},
+				"psalm.configPaths": {
+					"type": "array",
+					"default": [
+						"psalm.xml",
+						"psalm.xml.dist"
+					],
+					"description": "A list of files to checkup for psalm configuration (relative to the workspace directory)"
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,16 @@ function isFile(path: string): boolean {
     }
 }
 
+function filterPath(paths: string[], workspacePath: string): string|null {
+    for (var configPath of paths) {
+        if (isFile(path.join(workspacePath, configPath))) {
+            return configPath;
+        }
+    }
+
+    return null;
+}
+
 // Returns true if psalm.psalmScriptPath supports the language server protocol.
 async function checkPsalmHasLanguageServer(context: vscode.ExtensionContext, phpExecutablePath: string, psalmScriptPath: string): Promise<boolean> {
     const exists: boolean = isFile(psalmScriptPath);


### PR DESCRIPTION
So we can configure where to lookup for a config file. I put an array so we can check multiple files, relative to the workspace path (so we can have a `psalm.xml` and a `psalm.xml.dist` as it was before).

Not really fluent in typescript, so I did the best I could.

The build passes so here goes nothing...