### PR TITLE
Allow absolute config paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"lint": "tslint -c tslint.json \"src/**/*.ts\"",
 		"semantic-release": "semantic-release"
 	},
+	"extensionKind": ["workspace"],
 	"contributes": {
 		"configuration": {
 			"type": "object",


### PR DESCRIPTION
I tried using this plugin with ["Remote Containers"](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)-extension without success. It couldn't find the `psalm.xml` file. The file was not in the root of the workspaceFolder but one down (in `${workspaceFolder}/src`).

Even after setting `psalm.configPaths` I couldn't get it to work. After a few hours of digging I finally got it running by allowing setting absolute paths to the config (it will try the path as given without prefixing it with the workspaceFolderPath).

I also set the `extensionKind` to `workspace`. It basically means that it wants to be where the workspace (vscode-server) is installed instead of on the UI-side. More info here: [doc](https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location).

More info on Remote Containers here: [docs](https://code.visualstudio.com/docs/remote/containers).