### PR TITLE
Added new config options and functionality

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
 			"name": "Launch Extension",
 			"type": "extensionHost",
 			"request": "launch",
+			"preLaunchTask": "build",
 			"runtimeExecutable": "${execPath}",
 			"args": [
 			  	"--extensionDevelopmentPath=${workspaceRoot}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
 		"out": true // set this to false to include "out" folder in search results
 	},
 	"npm.exclude": ["**/src"],
-	"npm.enableScriptExplorer": true
+	"npm.enableScriptExplorer": true,
+	"typescript.tsdk": "node_modules\\typescript\\lib"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,7 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
+		  "label": "build",
 		  "type": "npm",
 		  "script": "build",
 		  "problemMatcher": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "psalm-vscode-plugin",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -872,9 +872,9 @@
 			"dev": true
 		},
 		"diff": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-			"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 			"dev": true
 		},
 		"dir-glob": {
@@ -1948,12 +1948,20 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
+				"minimist": "^1.2.5"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				}
 			}
 		},
 		"modify-values": {
@@ -6053,9 +6061,9 @@
 			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
 			"dev": true
 		},
 		"tslint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -351,15 +351,15 @@
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
 		},
 		"@types/semver": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.1.tgz",
+			"integrity": "sha512-+beqKQOh9PYxuHvijhVl+tIHvT6tuwOrE9m14zd+MT2A38KoKZhh7pYJ0SNleLtwDsiIxHDsIk9bv01oOxvSvA==",
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.30.0.tgz",
-			"integrity": "sha512-xRas+PW/fM/MoonB+Pawg48bGTjCqJsFUFwZpH/q2oW80AMHGDAUTUqySBnqeQ18e/SNi7NOCf3ZkYOzKm3Pqw==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
+			"integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
 			"dev": true
 		},
 		"JSONStream": {
@@ -775,6 +775,13 @@
 				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
 			}
 		},
 		"crypto-random-string": {
@@ -2018,6 +2025,11 @@
 					"version": "2.8.5",
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
 					"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -5279,6 +5291,14 @@
 			"dev": true,
 			"requires": {
 				"semver": "^5.1.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"parse5": {
@@ -5670,9 +5690,9 @@
 			}
 		},
 		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 		},
 		"semver-compare": {
 			"version": "1.0.0",
@@ -6057,6 +6077,14 @@
 				"semver": "^5.3.0",
 				"tslib": "^1.8.0",
 				"tsutils": "^2.29.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"tsutils": {
@@ -6184,35 +6212,50 @@
 				"url-join": "^1.1.0",
 				"yauzl": "^2.3.1",
 				"yazl": "^2.2.2"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"vscode-jsonrpc": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-			"integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+			"version": "5.1.0-next.1",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.1.0-next.1.tgz",
+			"integrity": "sha512-mwLDojZkbmpizSJSmp690oa9FB9jig18SIDGZeBCvFc2/LYSRvMm/WwWtMBJuJ1MfFh7rZXfQige4Uje5Z9NzA=="
 		},
 		"vscode-languageclient": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz",
-			"integrity": "sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==",
+			"version": "7.0.0-next.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0-next.1.tgz",
+			"integrity": "sha512-JrjCUhLpQZxQ5VpWpilOHDMhVsn0fdN5jBh1uFNhSr5c2loJvRdr9Km2EuSQOFfOQsBKx0+xvY8PbsypNEcJ6w==",
 			"requires": {
-				"semver": "^5.5.0",
-				"vscode-languageserver-protocol": "3.14.1"
+				"semver": "^6.3.0",
+				"vscode-languageserver-protocol": "3.16.0-next.2"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-			"integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+			"version": "3.16.0-next.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.2.tgz",
+			"integrity": "sha512-atmkGT/W6tF0cx4SaWFYtFs2UeSeC28RPiap9myv2YZTaTCFvTBEPNWrU5QRKfkyM0tbgtGo6T3UCQ8tkDpjzA==",
 			"requires": {
-				"vscode-jsonrpc": "^4.0.0",
-				"vscode-languageserver-types": "3.14.0"
+				"vscode-jsonrpc": "5.1.0-next.1",
+				"vscode-languageserver-types": "3.16.0-next.1"
 			}
 		},
 		"vscode-languageserver-types": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-			"integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+			"version": "3.16.0-next.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.1.tgz",
+			"integrity": "sha512-tZFUSbyjUcrh+qQf13ALX4QDdOfDX0cVaBFgy7ktJ0VwS7AW/yRKgGPSxVqqP9OCMNPdqP57O5q47w2pEwfaUg=="
 		},
 		"vscode-test": {
 			"version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -78,8 +78,14 @@
 						"array"
 					],
 					"default": [
-						{ "scheme": "file", "language": "php" },
-						{ "scheme": "untitled", "language": "php" }
+						{
+							"scheme": "file",
+							"language": "php"
+						},
+						{
+							"scheme": "untitled",
+							"language": "php"
+						}
 					],
 					"description": "A list of file extensions to request Psalm to analyze. By default, this only includes 'php' (Modifying requires restart)"
 				},
@@ -107,10 +113,9 @@
 					"description": "A list of files to checkup for psalm configuration (relative to the workspace directory)"
 				},
 				"psalm.hideStatusMessageWhenRunning": {
-					"type":"boolean",
+					"type": "boolean",
 					"default": false,
 					"description": "This will hide the Psalm status from the status bar when it is started and running.  This is useful to clear up a cluttered status bar."
-
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "VS Code Plugin for Psalm",
 	"author": "Matthew Brown",
 	"license": "MIT",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"publisher": "getpsalm",
 	"categories": [
 		"Linters",
@@ -46,6 +46,18 @@
 					"default": null,
 					"description": "Optional, defaults to searching for \"php\". The path to a PHP 7.0+ executable to use to execute the Psalm server. The PHP 7.0+ installation should preferably include and enable the PHP module `pcntl`. (Modifying requires restart)"
 				},
+				"psalm.phpExecutableArgs": {
+					"type": [
+						"array",
+						"null"
+					],
+					"default": [
+						"-dxdebug.remote_autostart=0",
+						"-dxdebug.remote_enable=0",
+						"-dxdebug_profiler_enable=0"
+					],
+					"description": "Optional (Advanced), default is '-dxdebug.remote_autostart=0 -dxdebug.remote_enable=0 -dxdebug_profiler_enable=0'.  Additional PHP executable CLI arguments to use."
+				},
 				"psalm.psalmScriptPath": {
 					"type": [
 						"string",
@@ -66,7 +78,8 @@
 						"array"
 					],
 					"default": [
-						"php"
+						{ "scheme": "file", "language": "php" },
+						{ "scheme": "untitled", "language": "php" }
 					],
 					"description": "A list of file extensions to request Psalm to analyze. By default, this only includes 'php' (Modifying requires restart)"
 				},

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"url": "https://github.com/psalm/psalm-vscode-plugin"
 	},
 	"engines": {
-		"vscode": "^1.30.0"
+		"vscode": "^1.44.0"
 	},
 	"activationEvents": [
 		"onLanguage:php",
@@ -105,6 +105,12 @@
 						"psalm.xml.dist"
 					],
 					"description": "A list of files to checkup for psalm configuration (relative to the workspace directory)"
+				},
+				"psalm.hideStatusMessageWhenRunning": {
+					"type":"boolean",
+					"default": false,
+					"description": "This will hide the Psalm status from the status bar when it is started and running.  This is useful to clear up a cluttered status bar."
+
 				}
 			}
 		}
@@ -113,8 +119,8 @@
 		"@types/mocha": "^2.2.48",
 		"@types/mz": "0.0.31",
 		"@types/node": "^8.10.59",
-		"@types/semver": "^5.5.0",
-		"@types/vscode": "1.30",
+		"@types/semver": "^6.2.1",
+		"@types/vscode": "^1.44.0",
 		"husky": "^3.1.0",
 		"tslint": "^5.20.1",
 		"typescript": "^3.7.4",
@@ -124,7 +130,7 @@
 	"dependencies": {
 		"mz": "^2.7.0",
 		"semantic-release": "^15.14.0",
-		"semver": "^5.7.1",
-		"vscode-languageclient": "^5.2.1"
+		"semver": "^6.3.0",
+		"vscode-languageclient": "^7.0.0-next.1"
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,125 @@
+{
+    "rules": {
+      "arrow-return-shorthand": true,
+      "callable-types": true,
+      "class-name": true,
+      "comment-format": [
+        true,
+        "check-space"
+      ],
+      "curly": true,
+      "deprecation": {
+        "severity": "warn"
+      },
+      "eofline": true,
+      "forin": true,
+      "import-spacing": true,
+      "indent": [
+        true,
+        "spaces"
+      ],
+      "interface-over-type-literal": true,
+      "label-position": true,
+      "max-line-length": [
+        true,
+        140
+      ],
+      "member-access": false,
+      "member-ordering": [
+        true,
+        {
+          "order": [
+            "static-field",
+            "instance-field",
+            "static-method",
+            "instance-method"
+          ]
+        }
+      ],
+      "no-arg": true,
+      "no-bitwise": true,
+      "no-console": [
+        true,
+        "debug",
+        "info",
+        "time",
+        "timeEnd",
+        "trace"
+      ],
+      "no-construct": true,
+      "no-debugger": true,
+      "no-duplicate-super": true,
+      "no-empty": false,
+      "no-empty-interface": true,
+      "no-eval": true,
+      "no-inferrable-types": [
+        true,
+        "ignore-params"
+      ],
+      "no-misused-new": true,
+      "no-non-null-assertion": true,
+      "no-redundant-jsdoc": true,
+      "no-shadowed-variable": true,
+      "no-string-literal": false,
+      "no-string-throw": true,
+      "no-switch-case-fall-through": true,
+      "no-trailing-whitespace": true,
+      "no-unnecessary-initializer": true,
+      "no-unused-expression": true,
+      "no-use-before-declare": true,
+      "no-var-keyword": true,
+      "object-literal-sort-keys": false,
+      "one-line": [
+        true,
+        "check-open-brace",
+        "check-catch",
+        "check-else",
+        "check-whitespace"
+      ],
+      "prefer-const": true,
+      "quotemark": [
+        true,
+        "single"
+      ],
+      "radix": true,
+      "semicolon": [
+        true,
+        "always"
+      ],
+      "triple-equals": [
+        true,
+        "allow-null-check"
+      ],
+      "typedef-whitespace": [
+        true,
+        {
+          "call-signature": "nospace",
+          "index-signature": "nospace",
+          "parameter": "nospace",
+          "property-declaration": "nospace",
+          "variable-declaration": "nospace"
+        }
+      ],
+      "unified-signatures": true,
+      "variable-name": false,
+      "whitespace": [
+        true,
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type"
+      ],
+      "no-output-on-prefix": true,
+      "use-input-property-decorator": true,
+      "use-output-property-decorator": true,
+      "use-host-property-decorator": true,
+      "no-input-rename": true,
+      "no-output-rename": true,
+      "use-life-cycle-interface": true,
+      "use-pipe-transform-interface": true,
+      "component-class-suffix": true,
+      "directive-class-suffix": true
+    }
+  }
+  


### PR DESCRIPTION
- Added status to status bar.
- Added the php arguments config option.
- Added config option to hid status bar text if running.
- Added ability to have Psalm error codes and error help links (Psalm needs to merge https://github.com/vimeo/psalm/pull/3161 for this to work)
- Added telemetry data for startup in the status bar (Psalm needs to merge https://github.com/vimeo/psalm/pull/3161 for this to work)
- Added file watcher for php files that may get changed outside of vscode


All of the new functionality for the psalm language server checks that it supports those new option before using them so it is backwards compatible with the older version of PSalm language server (that does not have https://github.com/vimeo/psalm/pull/3161 merged in)
