### PR TITLE
Add Psalm config initialization if none found

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,14 @@
 					"default": null,
 					"description": "Optional (Advanced). If provided, this overrides the Psalm script to use, e.g. vendor/bin/psalm-language-server. (Modifying requires restart)"
 				},
+				"psalm.psalmClientScriptPath": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "Optional (Advanced). If provided, this overrides the Psalm script to use, e.g. vendor/bin/psalm. (Modifying requires restart)"
+				},
 				"psalm.enableDebugLog": {
 					"type": [
 						"boolean"


### PR DESCRIPTION
This reminds and motivates users to initialize Psalm for the project. 

Today I used this extension for the first time and thought this would be a nice addition to the extension.

## Questions
- Do we need to add an opt-out setting for this behavior?
- Perhaps we could also ask for installation of `vimeo/psalm` if it is not present, but `composer.json` and `vendor/` do exist?
- Should I take in the changes of #11?

![2020-09-14-22-02-43](https://user-images.githubusercontent.com/1165302/93132680-5c49dc00-f6d6-11ea-8994-5c7f378a2988.gif)
