### PR TITLE
Add a languager server ID

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -300,6 +300,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     // Create the language client and start the client.
     const lc = new LanguageClient(
+        'psalmLanguageServer',
         'Psalm Language Server',
         serverOptionsCallbackForDirectory(workspacePath),
         clientOptions


### PR DESCRIPTION
When calling `new LanguageClient`, it's possible to also pass an ID. This means one can set `psalmLanguageServer.trace.server` in Settings and get verbose LSP information from VS code. See https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server

Without this, I was not able to target this LSP.