### PR TITLE
Remove php glob pattern from workspaceContains in activationEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 	},
 	"activationEvents": [
 		"onLanguage:php",
-		"workspaceContains:**/*.php"
+        	"workspaceContains:psalm.xml",
+		"workspaceContains:psalm.xml.dist"
 	],
 	"main": "./out/extension",
 	"scripts": {


### PR DESCRIPTION
## Description

This PR was merged the other day. https://github.com/psalm/psalm-vscode-plugin/commit/2607a60ccae43bd6d23f3c90624bb74b04ec0fa0

I think that if you have activationEvents set to `workspaceContains:**/*.php`, you will have a situation like this issue. https://github.com/psalm/psalm-vscode-plugin/issues/28

Changed activationEvents.

## Notes

Or maybe you don't even need `onLanguage:php` itself. This is because it will be enabled even for PHP projects that do not use psalm. :(