### PR TITLE
Add "psalm.restartPsalmServer" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,20 @@
 					"description": "This will hide the Psalm status from the status bar when it is started and running.  This is useful to clear up a cluttered status bar."
 				}
 			}
+		},
+		"commands": [
+			{
+				"command": "psalm.restartPsalmServer",
+				"title": "Restart Psalm Language server",
+				"category": "psalm"
+			}
+		],
+		"menus": {
+			"commandPalette": [
+				{
+					"command": "psalm.restartPsalmServer"
+				}
+			]
 		}
 	},
 	"devDependencies": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+import { LanguageClient } from 'vscode-languageclient';
+
+interface Command {
+    id: string;
+    execute(): Promise<vscode.Disposable>;
+}
+
+function restartPsalmServer(client: LanguageClient): Command {
+    return {
+        id: 'psalm.restartPsalmServer',
+        async execute() {
+            await client.stop();
+            return client.start();
+        },
+    };
+}
+
+export function registerCommands(client: LanguageClient): vscode.Disposable[] {
+    const commands: Command[] = [restartPsalmServer(client)];
+
+    const disposables = commands.map((command) => {
+        return vscode.commands.registerCommand(command.id, command.execute);
+    });
+
+    return disposables;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,8 @@ import * as net from 'net';
 import * as url from 'url';
 import * as fs from 'fs';
 
+import { registerCommands } from './commands';
+
 async function showOpenSettingsPrompt(errorMessage: string): Promise<void> {
     const selected = await vscode.window.showErrorMessage(
         errorMessage,
@@ -380,7 +382,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // Push the disposable to the context's subscriptions so that the
     // client can be deactivated on extension deactivation
     const disposable = lc.start();
-    context.subscriptions.push(disposable);
+    context.subscriptions.push(...registerCommands(lc), disposable);
 
     await lc.onReady();
 


### PR DESCRIPTION
## Description

It would be useful to be able to restart only psalm-language-server, so we added this feature.

## Demo

![add-restart-psalmserver](https://user-images.githubusercontent.com/188642/105955368-84503f80-60b9-11eb-8e4b-feb604fdb458.gif)
