### PR TITLE
fix "--use-ini-defaults" option feature (typo?)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 					"default": null,
 					"description": "Optional (Advanced). If provided, this overrides the Psalm script to use, e.g. vendor/bin/psalm. (Modifying requires VSCode reload)"
 				},
-				"psalm.enableIniDefaults": {
+				"psalm.enableUseIniDefaults": {
 					"type": "boolean",
 					"default": false,
 					"description": "Enable this to use PHP-provided ini defaults for memory and error display. (Modifying requires restart)"

--- a/src/ConfigurationService.ts
+++ b/src/ConfigurationService.ts
@@ -45,8 +45,8 @@ export class ConfigurationService {
             workspaceConfiguration.get<boolean>('connectToServerWithTcp') ||
             false;
 
-        this.config.useIniDefaults =
-            workspaceConfiguration.get<boolean>('useIniDefaults') || false;
+        this.config.enableUseIniDefaults =
+            workspaceConfiguration.get<boolean>('enableUseIniDefaults') || false;
 
         this.config.analyzedFileExtensions = workspaceConfiguration.get<
             string[] | DocumentSelector

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -389,10 +389,10 @@ export class LanguageServer {
                 psalmScriptArgs.unshift('--verbose');
             }
 
-            const useIniDefaults =
-                this.configurationService.get<boolean>('useIniDefaults');
+            const enableUseIniDefaults =
+                this.configurationService.get<boolean>('enableUseIniDefaults');
 
-            if (useIniDefaults) {
+            if (enableUseIniDefaults) {
                 psalmScriptArgs.unshift('--use-ini-defaults');
             }
         }


### PR DESCRIPTION
## Description

In the configuration section of the package.json, "psalm.enableIniDefaults" is set. (enableIniDefaults)

The code uses "useIniDefaults".

Changed to `enableUseIniDefaults` as the setting and variable names seem to be incorrect.

**[Current]: configuration section in package.json**:

```
psalm-vscode-plugin$ rg "enableIniDefaults"
package.json
84:				"psalm.enableIniDefaults": {
```

**[Current]: The code uses `useIniDefaults`**

```
psalm-vscode-plugin$ rg "useIniDefaults"
src/ConfigurationService.ts
48:        this.config.useIniDefaults =
49:            workspaceConfiguration.get<boolean>('useIniDefaults') || false;

src/LanguageServer.ts
392:            const useIniDefaults =
393:                this.configurationService.get<boolean>('useIniDefaults');
395:            if (useIniDefaults) {
```