### PR TITLE
Allow setting arbitrary language server parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,14 @@
 					"default": null,
 					"description": "Optional (Advanced). If provided, this overrides the Psalm script to use, e.g. vendor/bin/psalm-language-server. (Modifying requires VSCode reload)"
 				},
+				"psalm.psalmScriptArgs": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [],
+					"description": "Optional (Advanced). Additional arguments to the Psalm language server. (Modifying requires VSCode reload)"
+				},
 				"psalm.psalmClientScriptPath": {
 					"type": "string",
 					"default": null,

--- a/src/ConfigurationService.ts
+++ b/src/ConfigurationService.ts
@@ -30,6 +30,10 @@ export class ConfigurationService {
             workspaceConfiguration.get<string>('psalmScriptPath') ||
             join('vendor', 'vimeo', 'psalm', 'psalm-language-server');
 
+        this.config.psalmScriptArgs = workspaceConfiguration.get<string[]>(
+            'psalmScriptArgs'
+        ) || [];
+
         this.config.maxRestartCount =
             workspaceConfiguration.get<number>('maxRestartCount') || 5;
 

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -293,6 +293,16 @@ export class LanguageServer {
         const languageServerVersion: string | null =
             await this.getPsalmLanguageServerVersion();
 
+        const extraServerArgs = this.configurationService.get<string[]>(
+            'psalmScriptArgs'
+        );
+
+        if (extraServerArgs) {
+            if (Array.isArray(extraServerArgs)) {
+                args.unshift(...extraServerArgs);
+            }
+        }
+
         const unusedVariableDetection = this.configurationService.get<boolean>(
             'unusedVariableDetection'
         );


### PR DESCRIPTION
Currently, there is no possibility to pass extra arguments to the language server, other than the ones for which there's already an option.
This pull request allows giving any number of extra parameters, so people can pass `--enable-autocomplete=false`, or whatever more parameters there are to come. Since I use Intelephense, the auto complete suggestions from the psalm server are just annoyingly interfering with Intelephense's.