### PR TITLE
Revert "Bump ts-loader from 9.2.6 to 9.2.8"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "psalm-vscode-plugin",
-	"version": "2.6.0",
+	"version": "2.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "2.6.0",
+			"version": "2.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/fs-extra": "^9.0.13",
@@ -23,12 +23,12 @@
 				"@types/which": "^2.0.1",
 				"husky": "^7.0.4",
 				"prettier": "^2.5.1",
-				"ts-loader": "^9.2.8",
+				"ts-loader": "^9.2.6",
 				"tslint": "^6.1.3",
-				"typescript": "^4.5.5",
-				"vsce": "^2.6.6",
-				"webpack": "^5.68.0",
-				"webpack-cli": "^4.9.2"
+				"typescript": "^4.5.4",
+				"vsce": "^2.6.2",
+				"webpack": "^5.65.0",
+				"webpack-cli": "^4.9.1"
 			},
 			"engines": {
 				"vscode": "^1.57.1"
@@ -2719,9 +2719,9 @@
 			}
 		},
 		"node_modules/ts-loader": {
-			"version": "9.2.8",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.8.tgz",
-			"integrity": "sha512-gxSak7IHUuRtwKf3FIPSW1VpZcqF9+MBrHOvBp9cjHh+525SjtCIJKVGjRKIAfxBwDGDGCFF00rTfzB1quxdSw==",
+			"version": "9.2.6",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
+			"integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.0",
@@ -5378,9 +5378,9 @@
 			}
 		},
 		"ts-loader": {
-			"version": "9.2.8",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.8.tgz",
-			"integrity": "sha512-gxSak7IHUuRtwKf3FIPSW1VpZcqF9+MBrHOvBp9cjHh+525SjtCIJKVGjRKIAfxBwDGDGCFF00rTfzB1quxdSw==",
+			"version": "9.2.6",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
+			"integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
 		"@types/which": "^2.0.1",
 		"husky": "^7.0.4",
 		"prettier": "^2.5.1",
-		"ts-loader": "^9.2.8",
+		"ts-loader": "^9.2.6",
 		"tslint": "^6.1.3",
 		"typescript": "^4.5.5",
 		"vsce": "^2.6.6",


### PR DESCRIPTION
Reverts psalm/psalm-vscode-plugin#158