### PR TITLE
Prevent focusing the output tab

### DIFF
--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -2,6 +2,7 @@ import {
     LanguageClient,
     StreamInfo,
     ErrorHandler,
+    RevealOutputChannelOn,
 } from 'vscode-languageclient/node';
 import { StatusBar, LanguageServerStatus } from './StatusBar';
 import { spawn, ChildProcess } from 'child_process';
@@ -56,6 +57,7 @@ export class LanguageServer {
             {
                 outputChannel: this.loggingService,
                 traceOutputChannel: this.loggingService,
+                revealOutputChannelOn: RevealOutputChannelOn.Never,
                 // Register the server for php (and maybe HTML) documents
                 documentSelector: this.configurationService.get<
                     string[] | DocumentSelector


### PR DESCRIPTION
Just a quick one to prevent the extension from stealing focus to the output tab

See: https://github.com/felixfbecker/vscode-php-intellisense/pull/454

Fixes: https://github.com/psalm/psalm-vscode-plugin/issues/141