### PR TITLE
Feature: restart language server on project switching when using workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "psalm-vscode-plugin",
 			"version": "2.6.0",
 			"license": "MIT",
 			"dependencies": {

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -95,6 +95,14 @@ export class LanguageServer {
         this.languageClient.onTelemetry(this.onTelemetry.bind(this));
     }
 
+    /**
+     * This will NOT restart the server.
+     * @param workspacePath
+     */
+    public setWorkspacePath(workspacePath: string): void {
+        this.workspacePath = workspacePath;
+    }
+
     public createDefaultErrorHandler(maxRestartCount?: number): ErrorHandler {
         if (maxRestartCount !== undefined && maxRestartCount < 0) {
             throw new Error(`Invalid maxRestartCount: ${maxRestartCount}`);

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -103,6 +103,14 @@ export class LanguageServer {
         this.workspacePath = workspacePath;
     }
 
+    /**
+     * This will NOT restart the server.
+     * @param psalmConfigPath
+     */
+    public setPsalmConfigPath(psalmConfigPath: string): void {
+        this.psalmConfigPath = psalmConfigPath;
+    }
+
     public createDefaultErrorHandler(maxRestartCount?: number): ErrorHandler {
         if (maxRestartCount !== undefined && maxRestartCount < 0) {
             throw new Error(`Invalid maxRestartCount: ${maxRestartCount}`);

--- a/src/LanguageServerErrorHandler.ts
+++ b/src/LanguageServerErrorHandler.ts
@@ -24,7 +24,7 @@ export default class LanguageServerErrorHandler implements ErrorHandler {
         if (this.restarts.length <= this.maxRestartCount) {
             return CloseAction.Restart;
         } else {
-            let diff =
+            const diff =
                 this.restarts[this.restarts.length - 1] - this.restarts[0];
             if (diff <= 3 * 60 * 1000) {
                 void showReportIssueErrorMessage(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -73,7 +73,9 @@ function reportIssue(
                 'report_issue_template.md'
             );
 
-            const userSettings = Object.entries(configurationService.getAll())
+            const userSettings = Object.entries(
+                configurationService.getAll()
+            )
                 .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
                 .join(EOL);
             const psalmLogs = loggingService.getContent().join(EOL);
@@ -88,7 +90,8 @@ function reportIssue(
             let psalmVersion: string | null = 'unknown';
             try {
                 psalmVersion =
-                    (await client.getPsalmLanguageServerVersion()) ?? 'unknown';
+                    (await client.getPsalmLanguageServerVersion()) ??
+                    'unknown';
             } catch (err) {
                 psalmVersion = err.message;
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,9 +101,6 @@ export async function activate(
     // restart the language server when changing workspaces
     const onWorkspacePathChange = async () => {
         loggingService.logInfo(`Workspace changed: ${workspacePath}`);
-        loggingService.logInfo(
-            `Creating a new language server for workspace: ${workspacePath}`
-        );
         languageServer.setWorkspacePath(workspacePath);
         languageServer.restart();
     };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ export async function activate(
             ? vscode.workspace.getWorkspaceFolder(
                   vscode.window.activeTextEditor.document.uri
               )
-            : undefined;
+            : workspaceFolders[0];
 
         const workspacePath = activeWorkspace
             ? activeWorkspace.uri.fsPath

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,17 +147,22 @@ export async function activate(
     });
 
     vscode.window.onDidChangeActiveTextEditor((e) => {
-        if (!vscode.window.activeTextEditor) {
+        if (!e) {
             return;
         }
 
-        activeWorkspace = vscode.workspace.getWorkspaceFolder(
-            vscode.window.activeTextEditor.document.uri
+        const tmpActiveWorkspace = vscode.workspace.getWorkspaceFolder(
+            e.document.uri
         );
 
-        workspacePath = activeWorkspace
-            ? activeWorkspace.uri.fsPath
+        const tmpWorkspacePath = tmpActiveWorkspace
+            ? tmpActiveWorkspace.uri.fsPath
             : workspaceFolders[0].uri.fsPath;
+
+        if (!tmpWorkspacePath || workspacePath === tmpWorkspacePath) return;
+
+        activeWorkspace = tmpActiveWorkspace;
+        workspacePath = tmpWorkspacePath;
 
         onWorkspacePathChange();
     });


### PR DESCRIPTION
Each time the user switches to a different project within a workspace the language server will [point to that project then restart](https://github.com/tncrazvan/psalm-vscode-plugin/blob/b3bf4607c4da68732e8b411f2392b48f46fa7c11/src/extension.ts#L102-L106).
Previously the language server would always point to the first project in the workspace ( see https://github.com/psalm/psalm-vscode-plugin/issues/104#issuecomment-1186513125 ).

Improvements are welcomed.

Related to #104 