### PR TITLE
add separate option for disableProvideHover

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,11 @@
                     "default": false,
                     "description": "Enable to disable autocomplete on methods and properties (Modifying requires VSCode reload)"
                 },
+                "psalm.disableProvideHover": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable to disable the providing hover definition on methods and properties (Modifying requires VSCode reload)"
+                },
                 "psalm.configPaths": {
                     "type": "array",
                     "items": {

--- a/src/ConfigurationService.ts
+++ b/src/ConfigurationService.ts
@@ -12,6 +12,7 @@ interface Config {
     psalmScriptPath?: string;
     psalmScriptArgs?: string[];
     disableAutoComplete: boolean;
+    disableProvideHover: boolean;
     maxRestartCount: integer;
     unusedVariableDetection: boolean;
     enableVerbose: boolean;
@@ -28,6 +29,7 @@ export class ConfigurationService {
     private config: Config = {
         maxRestartCount: 5,
         disableAutoComplete: false,
+        disableProvideHover: false,
         unusedVariableDetection: false,
         enableVerbose: false,
         connectToServerWithTcp: false,
@@ -79,6 +81,11 @@ export class ConfigurationService {
 
         this.config.disableAutoComplete = workspaceConfiguration.get(
             'disableAutoComplete',
+            false
+        );
+
+        this.config.disableProvideHover = workspaceConfiguration.get(
+            'disableProvideHover',
             false
         );
 

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -397,6 +397,14 @@ export class LanguageServer {
             args.unshift('--enable-autocomplete=false');
         }
 
+        const disableProvideHover = this.configurationService.get(
+            'disableProvideHover'
+        );
+
+        if (disableProvideHover) {
+            args.unshift('--enable-provide-hover=false');
+        }
+
         // Are we running psalm or psalm-language-server
         // if we are runing psalm them we need to forward to psalm-language-server
         const psalmHasLanguageServerOption: boolean =


### PR DESCRIPTION
I personally run other extensions that handle PHP method / property definitions for hover and autocomplete and while the extension currently has an option to disable the autocomplete it doesn't have one to disable the hover provider.

Looking at the psalm Language Server code I noticed that there was already a flag to disable the hover provider so I've added an option in the plugin to send that flag over when starting the Language Server.

The additions are made the same way that the 'Disable Auto Complete' option was passing along the
`--enable-provide-hover=false` flag to the Language Server.